### PR TITLE
Trust: Adjustments to casting order

### DIFF
--- a/src/map/ai/controllers/trust_controller.h
+++ b/src/map/ai/controllers/trust_controller.h
@@ -55,6 +55,8 @@ public:
 
     CBattleEntity* GetTopEnmity();
 
+    uint8 GetPartyPosition();
+
     std::unique_ptr<gambits::CGambitsContainer> m_GambitsContainer;
 
 private:
@@ -63,8 +65,6 @@ private:
 
     void Declump(CCharEntity* PMaster, CBattleEntity* PTarget);
     void PathOutToDistance(CBattleEntity* PTarget, float amount);
-
-    uint8 GetPartyPosition();
 
     CBattleEntity* m_LastTopEnmity;
 

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -15,6 +15,7 @@
 
 #include "../../weapon_skill.h"
 #include "../controllers/player_controller.h"
+#include "../controllers/trust_controller.h"
 
 namespace gambits
 {
@@ -45,7 +46,11 @@ namespace gambits
     {
         TracyZoneScoped;
 
-        if (tick < m_lastAction)
+        auto* controller      = static_cast<CTrustController*>(POwner->PAI->GetController());
+        uint8 currentPartyPos = controller->GetPartyPosition();
+        auto  position_offset = static_cast<std::chrono::milliseconds>(currentPartyPos * 10);
+
+        if ((tick + position_offset) < m_lastAction)
         {
             return;
         }
@@ -60,8 +65,6 @@ namespace gambits
 
         auto random_offset = static_cast<std::chrono::milliseconds>(tpzrand::GetRandomNumber(1000, 2500));
         m_lastAction       = tick + random_offset;
-
-        auto* controller = static_cast<CTrustController*>(POwner->PAI->GetController());
 
         // Deal with TP skills before any gambits
         // TODO: Should this be its own special gambit?

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3591,7 +3591,7 @@ inline int32 CLuaBaseEntity::bringPlayer(lua_State* L)
 inline int32 CLuaBaseEntity::getEquipID(lua_State* L)
 {
     TPZ_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC && m_PBaseEntity->objtype != TYPE_PET && m_PBaseEntity->objtype != TYPE_MOB);
+    TPZ_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
     TPZ_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 


### PR DESCRIPTION
• Found a crash while trust tried to use inline int32 CLuaBaseEntity::getEquipID(lua_State* L),
  The debug break was triggering due to TYPE_TRUST not being included in the check, but previously,
  it was checking for everything other than an NPC, so changed the break to be m_PBaseEntity->objtype == TYPE_NPC.

• Added a slight offset to the initial tick of trust gambits to allow for the ability to check if other trust are casting the same spell over each other,
  Note: this is only micro seconds and will not be noticeable in game.

• Added the checks in CTrustController::Cast to give the trust the ability to sense what other trust are casting, and will stop the following:
  • Stops trust casting Cure over each other if the target has over 50% missing, tested at multiple levels with current working trust.
  • Stops trust from casting the same buffs over each other, protectra, shellra ect.
    this will allow other trust to cast shellra for example when another trust is casting protectra as retail does, same with other buffs.
    In the case that a trust is casting a spell that is a higher version of the buff, the higher version will be allowed to cast, for example, refresh II over refresh.
    The same goes for de-buffing mobs.
    Note: This does not effect nuking in anyway.

The changes as a whole allow the trust to be more MP efficient and more retail like.

<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [X] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/topaz-next/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [X] that I have read the [Contributing Guide](https://github.com/topaz-next/topaz/blob/release/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/topaz-next/topaz/blob/release/CODE_OF_CONDUCT.md)
- [X] that I've _tested my code_ since the last commit in the PR, and will test after any later commits

**_Temporary_**:
- [X] that I understand there are large refactoring efforts going on right now, that these efforts touch every single Lua script and binding, and that my pull request might get put on hold to ensure there are not any conflicts with the refactoring work
